### PR TITLE
New verify-logs template

### DIFF
--- a/workflow-templates/verify_changelogs.yml
+++ b/workflow-templates/verify_changelogs.yml
@@ -17,3 +17,4 @@ jobs:
         #Example to change text file(s) location. It's starts at the root of the repo. Default is : unreleased-changes/*.txt
         #with:
         #  changeLogsLocation: some-location/*.txt
+        


### PR DESCRIPTION
------------ Origin ------------
This idea came from innovate hackathon 2021. The foundation team wanted to have change logs file automatically updated and then sended in the slack channel like the dev tooling team did in the deployement pipeline. 

------------ Description ------------
To make sure people didn't forget to populate the right file(s), we added a github actions to check wether the person creating the PR added the necessary information or not. As we will most likely reuse the actions on multiple of our repo, we wanted to create a template for it. 

For now, the action may reside in this repo [PR link](https://github.com/coveo/github-actions/pull/2). This template might change when we'll know for sure where the action will reside. 
