### PR TITLE
Added directory input

### DIFF
--- a/workflow-templates/maven-dependency-submission.yml
+++ b/workflow-templates/maven-dependency-submission.yml
@@ -1,7 +1,13 @@
 name: "Dependency Submission"
 
 on:
-  workflow_dispatch: { }
+  workflow_dispatch:
+    inputs:
+      directory:
+        description: "The directory that contains the pom.xml that will be used to generate the dependency graph from"
+        default: "."
+        required: false
+        type: string
 
   push:
     branches: [ $default-branch, $protected-branches ]
@@ -16,3 +22,5 @@ jobs:
   submit-dependencies:
     name: Dependency Submission
     uses: coveo/actions/.github/workflows/java-maven-openjdk11-dependency-submission.yml@main
+    with:
+        directory: ${{ inputs.directory }}


### PR DESCRIPTION
[DEF-663](https://coveord.atlassian.net/browse/DEF-663)

Adding `directory` input to the starter workflow so that the location of the `pom.xml` can be set for repos where it is not located directly at the `github.workspace`

[DEF-663]: https://coveord.atlassian.net/browse/DEF-663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ