### PR TITLE
chore: coveo/actions has moved to coveo-platform/actions DT-6947

### DIFF
--- a/workflow-templates/checkov.yml
+++ b/workflow-templates/checkov.yml
@@ -15,4 +15,4 @@ on:
 jobs:
   checkov:
     name: Checkov
-    uses: coveo/actions/.github/workflows/checkov.yml@main
+    uses: coveo-platform/actions/.github/workflows/checkov.yml@main

--- a/workflow-templates/maven-dependency-submission.yml
+++ b/workflow-templates/maven-dependency-submission.yml
@@ -21,6 +21,6 @@ on:
 jobs:
   submit-dependencies:
     name: Dependency Submission
-    uses: coveo/actions/.github/workflows/java-maven-openjdk11-dependency-submission.yml@main
+    uses: coveo-platform/actions/.github/workflows/java-maven-openjdk11-dependency-submission.yml@main
     with:
         directory: ${{ inputs.directory }}


### PR DESCRIPTION
**Note to reviewer: Merge this pull request when you approve it! Thanks!!**

https://coveord.atlassian.net/browse/DT-6947

Summary of changes:
  - The `coveo/actions` repository is being moved to `coveo-platform/actions`
